### PR TITLE
Slurm support + ed25519 ssh key support with pw + save_each_run option

### DIFF
--- a/qsuite/jobscripts/PBSdummy.sh
+++ b/qsuite/jobscripts/PBSdummy.sh
@@ -11,5 +11,8 @@
 # within PBS job (workaround for SGE option "-cwd")
 cd $PBS_O_WORKDIR
 
+# here go "server_cmds": server specific commands necessary to run the job 
+%s
+
 INDEX=$((PBS_ARRAYID-1))
 %s %s/job.py $INDEX

--- a/qsuite/jobscripts/SGEdummy.sh
+++ b/qsuite/jobscripts/SGEdummy.sh
@@ -15,6 +15,9 @@ fi
 export OMP_NUM_THREADS=1
 export USE_SIMPLE_THREADED_LEVEL3=1
 
+# here go "server_cmds": server specific commands necessary to run the job 
+%s
+
 INDEX=$((SGE_TASK_ID-1))
 %s %s/job.py $INDEX
 

--- a/qsuite/jobscripts/SLURMdummy.sh
+++ b/qsuite/jobscripts/SLURMdummy.sh
@@ -11,4 +11,4 @@
 %s
 
 INDEX=$((SLURM_ARRAY_TASK_ID-1))
-srun %s %s/job.py $INDEX
+srun %s -u %s/job.py $INDEX

--- a/qsuite/jobscripts/SLURMdummy.sh
+++ b/qsuite/jobscripts/SLURMdummy.sh
@@ -1,7 +1,7 @@
 #!%s
 
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=%s
+#SBATCH --mem-per-cpu=%s
 #SBATCH --array=%d-%d
 #SBATCH -o %s
 #SBATCH -e %s

--- a/qsuite/jobscripts/SLURMdummy.sh
+++ b/qsuite/jobscripts/SLURMdummy.sh
@@ -1,0 +1,14 @@
+#!%s
+
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=%s
+#SBATCH --array=%d-%d
+#SBATCH -o %s
+#SBATCH -e %s
+#SBATCH --priority=%d
+
+# here go "server_cmds": server specific commands necessary to run the job 
+%s
+
+INDEX=$((SLURM_ARRAY_TASK_ID-1))
+srun %s %s/job.py $INDEX

--- a/qsuite/qconfig.py
+++ b/qsuite/qconfig.py
@@ -63,6 +63,9 @@ class qconfig(object):
         self.jmin = 0
         self.jmax = len(self.parameter_list)-1
 
+        #get max # of internal runs
+        self.jmax_internal = len(self.internal_parameter_list)-1
+
     #======================== INHERIT PROPERTIES FROM THE CONFIG FILE ============================
 
     def get_cf(self,path):

--- a/qsuite/qsuite_binary.py
+++ b/qsuite/qsuite_binary.py
@@ -112,6 +112,7 @@ def qstat(cf,ssh,args):
 
 def init(qsuitefile,opts):
     qsuiteparser = get_qsuite(qsuitefile,init=True)
+    copy_template("env",opts)
     copy_template("config",opts)
     copy_template("simulation",opts)
     write_qsuite(qsuiteparser,qsuitefile)

--- a/qsuite/qsuite_binary.py
+++ b/qsuite/qsuite_binary.py
@@ -68,7 +68,8 @@ def update_git(cf,ssh):
 
 
 def wrap_results(cf,ssh):
-    ssh_command(ssh, "cd " + cf.serverpath + "; " + cf.pythonpath + " wrap_results.py;")
+    ssh_command(ssh, "cd " + cf.serverpath + "; " +
+                cf.server_cmds + "; " + cf.pythonpath + " wrap_results.py;")
     ssh_command(ssh, "cd " + cf.serverpath + "/results; gzip results.p" )
     ssh_command(ssh, "cd " + cf.serverpath + "/results; gzip times.p" )
     custom_wrap_results(cf,ssh)

--- a/qsuite/queuesys/wrap_results.py
+++ b/qsuite/queuesys/wrap_results.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from numpy import *
 import os
 import sys
+from pathlib import Path
 #import gzip
 
 try:
@@ -90,7 +91,11 @@ def wrap_results(is_local=False,localrespath="current_results"):
         else:
             pcoords = []
 
-        if os.path.exists(resultpath+"/times_%d.p" % j) and os.path.exists(resultpath+"/results_%d.p" % j):
+        if cf.save_each_run:
+            results_exists = len(list(Path(resultpath).glob("results_%d_*.p" % j))) == cf.jmax_internal+1
+        else:
+            results_exists = os.path.exists(resultpath+"/results_%d.p" % j)
+        if os.path.exists(resultpath+"/times_%d.p" % j) and results_exists:
 
             if loading_successful:
 
@@ -149,7 +154,11 @@ def wrap_results(is_local=False,localrespath="current_results"):
         for j in range(cf.jmax+1):
             os.remove(resultpath+"/times_%d.p" % j)
             if not cf.only_save_times:
-                os.remove(resultpath+"/results_%d.p" % j)
+                if cf.save_each_run:
+                    for j_internal in range(cf.jmax_internal+1):
+                        os.remove(resultpath+"/results_%d_%d.p" % (j,j_internal))
+                else:
+                    os.remove(resultpath+"/results_%d.p" % j)
     else: 
         i = 0
         missing_array_id_strings = []

--- a/qsuite/queuesys/wrap_results.py
+++ b/qsuite/queuesys/wrap_results.py
@@ -98,8 +98,14 @@ def wrap_results(is_local=False,localrespath="current_results"):
                     time = pickle.load(this_file)
 
                 if not cf.only_save_times:
-                    with open(resultpath+"/results_%d.p" % j,'rb') as this_file:
-                        res = pickle.load(this_file)
+                    if cf.save_each_run:
+                        res = []
+                        for j_internal in range(cf.jmax_internal+1):
+                            with open(resultpath+"/results_%d_%d.p" % (j,j_internal),'rb') as this_file:
+                                res.append(pickle.load(this_file))
+                    else:
+                        with open(resultpath+"/results_%d.p" % j,'rb') as this_file:
+                            res = pickle.load(this_file)
         else:
             if loading_successful:
                 print("*** Caught Exception: Files missing! Jobs with the following ARRAY IDs did not produce results:")

--- a/qsuite/submitjob.py
+++ b/qsuite/submitjob.py
@@ -16,12 +16,12 @@ def get_output_pattern(qname):
     """SLURM needs a different output pattern in its options"""
     s = "/output"
     if qname=="SLURM":
-        s+ = "/slurm-%A_%a.out"
+        s += "/slurm-%A_%a.out"
     return s
 
 def get_jobscript(cf,array_id=None):
     JOBSCRIPT = get_dummy(cf.queue)
-    out_pattern = get_output_pattern(qname)
+    out_pattern = get_output_pattern(cf.queue)
 
     if array_id is None:
         arr_id_min = cf.jmin+1

--- a/qsuite/submitjob.py
+++ b/qsuite/submitjob.py
@@ -12,8 +12,16 @@ def get_dummy(qname):
 
     return s
 
+def get_output_pattern(qname):
+    """SLURM needs a different output pattern in its options"""
+    s = "/output"
+    if qname=="SLURM":
+        s+ = "/slurm-%A_%a.out"
+    return s
+
 def get_jobscript(cf,array_id=None):
     JOBSCRIPT = get_dummy(cf.queue)
+    out_pattern = get_output_pattern(qname)
 
     if array_id is None:
         arr_id_min = cf.jmin+1
@@ -30,9 +38,10 @@ def get_jobscript(cf,array_id=None):
                 cf.memory,
                 arr_id_min,
                 arr_id_max,
-                cf.serverpath+"/output",
-                cf.serverpath+"/output",
+                cf.serverpath + out_pattern,
+                cf.serverpath + out_pattern,
                 cf.priority,
+                cf.server_cmds,
                 cf.pythonpath,
                 cf.serverpath,
                 )
@@ -70,10 +79,7 @@ def make_job_ready(cf,ssh,array_id=None):
     joblocal_names = []
 
     if type(array_id) is not list and type(array_id) is not tuple:
-        is_list = True
         array_id = [ array_id ]
-    else:
-        is_list = False
 
     for a_id in array_id:
         jobscript = get_jobscript(cf,a_id)
@@ -126,6 +132,11 @@ def start_job(cf,ssh,array_id=None):
         elif cf.queue=="PBS":
             ssh_command(ssh,"cd " +cf.serverpath+";\
                              jobID=`qsub " + cf.basename + suffix +"`;\
+                             echo $jobID > .jobid;")
+        elif cf.queue=="SLURM":
+            ssh_command(ssh,"cd " +cf.serverpath+";\
+                             jobID=`sbatch " + cf.basename + suffix +"`;\
+                             jobID=`echo $jobID | awk 'match($0,/[0-9]+/){print substr($0, RSTART, RLENGTH)}'`;\
                              echo $jobID > .jobid;")
         else:
             print("Unknown queue:",cf.queue)

--- a/qsuite/template.py
+++ b/qsuite/template.py
@@ -52,6 +52,8 @@ def reset(mode):
 
 def copy_template(mode,options=[]):
 
+    if mode == "env":
+        filename = "env"
     if mode == "config":
         filename = "qsuite_config.py"
     elif mode == "simulation":

--- a/qsuite/template.py
+++ b/qsuite/template.py
@@ -32,6 +32,8 @@ def reset(mode):
 
     if mode == "config":
         filename = "qsuite_config.py"
+    elif mode == "env":
+        filename = "env"
     elif mode == "simulation":
         filename = "simulation.py"
     elif mode == "customwrap":
@@ -52,10 +54,10 @@ def reset(mode):
 
 def copy_template(mode,options=[]):
 
-    if mode == "env":
-        filename = "env"
     if mode == "config":
         filename = "qsuite_config.py"
+    elif mode == "env":
+        filename = "env"
     elif mode == "simulation":
         filename = "simulation.py"
     elif mode == "customwrap":
@@ -87,6 +89,8 @@ def set_default_file(mode,sourcefile):
 
     if mode == "config":
         filename = "qsuite_config.py"
+    elif mode == "env":
+        filename = "env"
     elif mode == "simulation":
         filename = "simulation.py"
     elif mode == "customwrap":

--- a/qsuite/templates/env
+++ b/qsuite/templates/env
@@ -1,0 +1,2 @@
+pkey_file="/path/to/keyfile/id_rsa"
+password="password_of_keyfile_or_delete_this_line_if_no_password"

--- a/qsuite/templates/qsuite_config.py
+++ b/qsuite/templates/qsuite_config.py
@@ -6,6 +6,7 @@ basename = "experimentname"
 
 seed = -1
 N_measurements = 1
+save_each_run = False
 
 measurements = range(N_measurements)
 params1 = range(3)
@@ -50,7 +51,7 @@ resultpath = serverpath + "/results"
 #============ CLUSTER PREPARATION ====================================
 #====== e.g. bash code loading modules to enable python:    ==========
 #======   "ml +development/24.04 +GCCcore/13.3.0 +Python"   ==========
-server_cmds = ""
+server_cmds = " "
 
 
 #============== LOCAL SETTINGS ============

--- a/qsuite/templates/qsuite_config.py
+++ b/qsuite/templates/qsuite_config.py
@@ -32,8 +32,10 @@ standard_parameters = [
 
 only_save_times = False
 
-#============== QUEUE ==================
-queue = "SGE"
+#============== QUEUE =============================================
+#=============== set queing system used at your server          ===
+#=============== queue can be one of ['PBS', 'SGE', 'SLURM']    ===
+queue = "SLURM"
 memory = "1G"
 priority = 0
 
@@ -50,7 +52,7 @@ resultpath = serverpath + "/results"
 
 #============ CLUSTER PREPARATION ====================================
 #====== e.g. bash code loading modules to enable python:    ==========
-#======   "ml +development/24.04 +GCCcore/13.3.0 +Python"   ==========
+#======   "ml purge; ml +development/24.04 +GCCcore/13.3.0 +Python"   ==========
 server_cmds = " "
 
 

--- a/qsuite/templates/qsuite_config.py
+++ b/qsuite/templates/qsuite_config.py
@@ -47,6 +47,12 @@ name = basename + "_NMEAS_" + str(N_measurements) + "_ONLYSAVETIME_" + str(only_
 serverpath = "/home/"+username +"/"+ projectname + "/" + name 
 resultpath = serverpath + "/results"
 
+#============ CLUSTER PREPARATION ====================================
+#====== e.g. bash code loading modules to enable python:    ==========
+#======   "ml +development/24.04 +GCCcore/13.3.0 +Python"   ==========
+server_cmds = ""
+
+
 #============== LOCAL SETTINGS ============
 localpath = os.path.join(os.getcwd(),"results_"+name)
 n_local_cpus = 1
@@ -55,4 +61,3 @@ n_local_cpus = 1
 git_repos = [
                 ( "/path/to/repo", pythonpath + " setup.py install --user" )
             ]
-

--- a/qsuite/templates/qsuite_config.py
+++ b/qsuite/templates/qsuite_config.py
@@ -62,5 +62,5 @@ n_local_cpus = 1
 
 #========================
 git_repos = [
-                ( "/path/to/repo", pythonpath + " setup.py install --user" )
+                ( "/path/to/repo", pythonpath + " -m pip install -e . --user" )
             ]

--- a/qsuite/templates/qsuite_config.py
+++ b/qsuite/templates/qsuite_config.py
@@ -50,9 +50,9 @@ name = basename + "_NMEAS_" + str(N_measurements) + "_ONLYSAVETIME_" + str(only_
 serverpath = "/home/"+username +"/"+ projectname + "/" + name 
 resultpath = serverpath + "/results"
 
-#============ CLUSTER PREPARATION ====================================
-#====== e.g. bash code loading modules to enable python:    ==========
-#======   "ml purge; ml +development/24.04 +GCCcore/13.3.0 +Python"   ==========
+#============ CLUSTER PREPARATION ==================================================
+#======  bash code loading modules to enable python:                      ==========
+#======  e.g. "ml purge; ml +development/24.04 +GCCcore/13.3.0 +Python"   ==========
 server_cmds = " "
 
 
@@ -60,7 +60,7 @@ server_cmds = " "
 localpath = os.path.join(os.getcwd(),"results_"+name)
 n_local_cpus = 1
 
-#========================
+#============= GIT SETTINGS     ============
 git_repos = [
                 ( "/path/to/repo", server_cmds + "; " + pythonpath + " -m pip install -e . --user" )
             ]

--- a/qsuite/templates/qsuite_config.py
+++ b/qsuite/templates/qsuite_config.py
@@ -62,5 +62,5 @@ n_local_cpus = 1
 
 #========================
 git_repos = [
-                ( "/path/to/repo", pythonpath + " -m pip install -e . --user" )
+                ( "/path/to/repo", server_cmds + "; " + pythonpath + " -m pip install -e . --user" )
             ]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(name='qsuite',
         'paramiko>=2.7.2',
         'pathos>=0.2.7',
         'tabulate>=0.8.7',
+        'python_dotenv>=1.0.0',
+        'pathlib>=1.0.1',
       ],
       dependency_links=[
           ],


### PR DESCRIPTION
Hi Benni, I added the file:
`jobscripts/SLURMdummy.sh`
and modified the code so that slurm-queuing system is also supported.
Just tested with some simulations, and it works fine.

Additionally, now the user is able to use also rsa or ed25519 ssh-key-types with pw.
The path to the key and its pw, are meant to be saved in a hidden .env file.
The template env file is created with `qsuite init` and is located here:
`templates/env`

There are 2 major modifications in `qsuit_config.py`:
A) the option `save_each_run=False`: if it is true simulation run is saved, i.e. for each internal parameter combination.
* It saves the results not as results/result_1.p but as results/result_1_1.p
* It also wraps the results correctly at the end
B) There is now the section "CLUSTER PREPARATION", it contains the field "server_cmds" and is as default empty.
* on some clusters you need to load modules, in order to enable python or other libraries, this is done here
* there is also and example in comments

Bests Pascal